### PR TITLE
sdk-browser: update tag snippet

### DIFF
--- a/packages/screeb-sdk-browser/docs/README.md
+++ b/packages/screeb-sdk-browser/docs/README.md
@@ -75,7 +75,7 @@ ___
 
 ### ScreebObject
 
-Ƭ **ScreebObject**: `ScreebFunction` & { `q?`: `unknown`[][]  }
+Ƭ **ScreebObject**: `ScreebFunction` & { `q?`: { `args`: `unknown`[] ; `ko`: (`reason?`: `unknown`) => `void` ; `ok`: (`value?`: `unknown`) => `void` ; `v`: `number`  }[]  }
 
 This is the Screeb object publicly exposed in browser `window`.
 

--- a/packages/screeb-sdk-browser/src/index.test.ts
+++ b/packages/screeb-sdk-browser/src/index.test.ts
@@ -37,11 +37,16 @@ describe("Screeb", () => {
       Screeb.init("website-uuid", "user-uuid", { test: 123 });
 
       expect(window.$screeb?.q).toEqual([
-        [
-          "init",
-          "website-uuid",
-          { identity: { id: "user-uuid", properties: { test: 123 } } },
-        ],
+        {
+          args: [
+            "init",
+            "website-uuid",
+            { identity: { id: "user-uuid", properties: { test: 123 } } },
+          ],
+          ko: expect.any(Function),
+          ok: expect.any(Function),
+          v: 1,
+        },
       ]);
     });
   });

--- a/packages/screeb-sdk-browser/src/index.ts
+++ b/packages/screeb-sdk-browser/src/index.ts
@@ -18,7 +18,16 @@ export type ScreebOptions = {
 type ScreebFunction = (..._: unknown[]) => void | Promise<unknown>;
 
 /** This is the Screeb object publicly exposed in browser `window`. */
-export type ScreebObject = ScreebFunction & { q?: unknown[][] };
+export type ScreebObject = ScreebFunction & {
+  q?: {
+    args: unknown[];
+    // eslint-disable-next-line no-unused-vars
+    ko: (reason?: unknown) => void;
+    // eslint-disable-next-line no-unused-vars
+    ok: (value?: unknown) => void;
+    v: number;
+  }[];
+};
 
 /** This is the object returned by the function `identityGet()`. */
 export type ScreebIdentityGetReturn = {
@@ -83,9 +92,17 @@ export const load = (options: ScreebOptions = {}) =>
     _window.$screeb =
       _window.$screeb ??
       function (...args) {
-        if (_window.$screeb) {
-          (_window.$screeb.q = _window.$screeb.q ?? []).push(args);
-        }
+        return new Promise((a, b) => {
+          if (_window.$screeb) {
+            return (_window.$screeb.q = _window.$screeb.q ?? []).push({
+              args,
+              ko: b,
+              ok: a,
+              v: 1,
+            });
+          }
+          return 0;
+        });
       };
 
     _window.document.head.appendChild(scriptElement);


### PR DESCRIPTION
@MD4 why not delete the preceding `if (_window.$screeb) {` ?

Please confirm we don't need to make this update elsewhere.
