### PR TITLE
fix(screeb-sdk-react): fix surveyStart helper typing

### DIFF
--- a/packages/screeb-sdk-react/docs/README.md
+++ b/packages/screeb-sdk-react/docs/README.md
@@ -517,7 +517,7 @@ ___
 
 ### SurveyStartFunction
 
-Ƭ **SurveyStartFunction**: (`surveyId`: `string`, `allowMultipleResponses`: `boolean`, `hiddenFields`: `PropertyRecord`, `hooks`: `Hooks`, `language`: `string`) => `Promise`\<`unknown`\>
+Ƭ **SurveyStartFunction**: (`surveyId`: `string`, `allowMultipleResponses`: `boolean`, `hiddenFields`: `PropertyRecord`, `hooks?`: `Hooks`, `language?`: `string`) => `Promise`\<`unknown`\>
 
 Starts a survey by its ID.
 
@@ -538,7 +538,7 @@ surveyStart(
 
 #### Type declaration
 
-▸ (`surveyId`, `allowMultipleResponses`, `hiddenFields`, `hooks`, `language`): `Promise`\<`unknown`\>
+▸ (`surveyId`, `allowMultipleResponses`, `hiddenFields`, `hooks?`, `language?`): `Promise`\<`unknown`\>
 
 ##### Parameters
 
@@ -547,8 +547,8 @@ surveyStart(
 | `surveyId` | `string` |
 | `allowMultipleResponses` | `boolean` |
 | `hiddenFields` | `PropertyRecord` |
-| `hooks` | `Hooks` |
-| `language` | `string` |
+| `hooks?` | `Hooks` |
+| `language?` | `string` |
 
 ##### Returns
 

--- a/packages/screeb-sdk-react/src/types.ts
+++ b/packages/screeb-sdk-react/src/types.ts
@@ -345,8 +345,8 @@ export type SurveyStartFunction = (
   surveyId: string,
   allowMultipleResponses: boolean,
   hiddenFields: PropertyRecord,
-  hooks: Hooks,
-  language: string,
+  hooks?: Hooks,
+  language?: string,
 ) => Promise<unknown>;
 
 /**


### PR DESCRIPTION
👋,

I'd like to suggest a change on the `surveyStart` type definition in `@screeb/sdk-react` package.

Since this recent commit https://github.com/ScreebApp/sdk-js/commit/e2f4b6c443e50e28bae4ecce447f319f0e523021 a new param has been added to the function signature (`language`) and it seems optional like the `hooks` param.

It seems to have an inconsistency between the implementation and the type definition in `packages/screeb-sdk-react/src/types.ts`.

In this type, `hooks` and `language` was added as mandatories.

I can be wrong but this looks like a breaking change when using the sdk because 2 news params are now mandatories and we can't upgrade until we use it (even the `hooks`).

Can you consider this and having a look?

Thanks for your help 🙏
